### PR TITLE
Fix implicit argument order for TypeApplications

### DIFF
--- a/Data/Types/Injective.hs
+++ b/Data/Types/Injective.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ExplicitForall #-}
 
 -- |Injective types. This module contains the 'Injective' typeclass and instances
 --  for the following equivalence classes:
@@ -47,7 +48,7 @@ import qualified Numeric.Peano as PN
 --  @to@ should be a total function. No cheating by it undefined for parts of the set!
 class Injective a b where
    -- |Converts a value of type @a@ "losslessly" to one of type @b@.
-   to :: a -> b
+   to :: forall b a. a -> b
 
 instance Injective a a where
    to = id

--- a/Data/Types/Isomorphic.hs
+++ b/Data/Types/Isomorphic.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ExplictForall #-}
 
 -- |Contains the class definition of 'Iso', indicating isomorphism between two
 --  types.
@@ -28,27 +29,17 @@ import Data.Types.Injective
 --
 --  [@Isomorphism@]
 -- @
--- isoFrom . isoTo = id
+-- from . to = id
 -- @
 --
 --  Reflexivity, symmetry and transitivity are then "free":
 --
 -- @
--- instance Iso a a where
---    isoTo = id
---    isoFrom = id
+-- instance Iso a a 
 -- @
 --
 -- @
--- instance Iso a b => Iso b a where
---    isoTo = isoFrom
---    isoFrom = isoTo
--- @
---
--- @
--- instance (Iso a b, Iso b c) => Iso a c where
---   isoTo = isoTo . isoTo
---   isFrom = isoFrom . isoFrom
+-- instance (Iso a b, Iso b c) => Iso a c 
 -- @
 --
 --  Out of these, only the first one (reflexivity) is actually implemented,
@@ -58,7 +49,7 @@ import Data.Types.Injective
 class (Injective a b, Injective b a) => Iso a b where
 
 -- |Synonym for 'to'.
-from :: (Iso a b) => b -> a
+from :: forall b a. (Iso a b) => b -> a
 from = to
 
 instance Iso a a where


### PR DESCRIPTION
`to` can lead to ambiguities. It's much nice to write `to @ String` as semantic for.. 'make this a String', vs having to note both type `to @ Text @ String`.