### PR TITLE
Implement #3 Add equivalence of finite sequences

### DIFF
--- a/Data/Types/Isomorphic.hs
+++ b/Data/Types/Isomorphic.hs
@@ -12,8 +12,10 @@ module Data.Types.Isomorphic (
 
 import qualified Numeric.Natural as N
 import qualified Numeric.Peano as PN
+import qualified Data.Sequence as S
 import qualified Data.Text as TS
 import qualified Data.Text.Lazy as TL
+import qualified Data.Vector.Generic as VG
 
 import Data.Types.Injective
 
@@ -67,3 +69,7 @@ instance Iso TL.Text TS.Text
 -- Peano wholes and integers.
 instance Iso PN.Whole Integer
 instance Iso Integer PN.Whole
+
+-- equivalence class of finite sequences
+instance (VG.Vector v a) => Iso (S.Seq a) (v a)
+instance (VG.Vector v a) => Iso (v a) (S.Seq a)

--- a/type-iso.cabal
+++ b/type-iso.cabal
@@ -22,5 +22,12 @@ source-repository head
 library
   exposed-modules:     Data.Types.Isomorphic, Data.Types.Injective
   other-extensions:    MultiParamTypeClasses, FlexibleInstances, FlexibleContexts, ExplicitForAll, GADTs
-  build-depends:       base >=4.7 && <5, nats >=0.2, text >=1.1, numericpeano >= 0.2, data-default >= 0.5
+  build-depends:       base >=4.7 && <5
+                     , containers >= 0.5.6.2
+                     , nats >=0.2
+                     , text >=1.1
+                     , numericpeano >= 0.2
+                     , data-default >= 0.5
+                     , vector >= 0.5
+                     , vector-builder >= 0.3.7
   default-language:    Haskell2010


### PR DESCRIPTION
Add the equivalence of `Data.Sequence.Seq a` from package `containers` and `Data.Vector.Generic.Vector v a => v a` from package `vector`, making use of package `vector-builder`.